### PR TITLE
fix: revert to react-icons@2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-helmet": "^5.2.0",
-    "react-icons": "^3.5.0",
+    "react-icons": "^2.2.7",
     "xstate": "^4.4.0"
   },
   "devDependencies": {

--- a/src/components/feedback-widget/feedback-form.js
+++ b/src/components/feedback-widget/feedback-form.js
@@ -5,13 +5,11 @@ import WidgetWrapper from "./widget-wrapper"
 import { SubmitButton, CloseButton, focusStyle } from "./buttons"
 import { Actions, Title, ScreenReaderText } from "./styled-elements"
 import RatingOption from "./rating-option"
-import {
-  MdSentimentDissatisfied,
-  MdSentimentNeutral,
-  MdSentimentVerySatisfied,
-  MdSend,
-  MdRefresh,
-} from "react-icons/md"
+import MdSentimentDissatisfied from "react-icons/lib/md/sentiment-dissatisfied"
+import MdSentimentNeutral from "react-icons/lib/md/sentiment-neutral"
+import MdSentimentVerySatisfied from "react-icons/lib/md/sentiment-very-satisfied"
+import MdSend from "react-icons/lib/md/send"
+import MdRefresh from "react-icons/lib/md/refresh"
 
 const Form = styled("form")`
   margin-bottom: 0;

--- a/src/components/feedback-widget/feedback-widget.js
+++ b/src/components/feedback-widget/feedback-widget.js
@@ -8,7 +8,7 @@ import FeedbackForm from "./feedback-form"
 import SubmitSuccess from "./submit-success"
 import SubmitError from "./submit-error"
 import { ScreenReaderText, WidgetContainer } from "./styled-elements"
-import { MdClose } from "react-icons/md"
+import MdClose from "react-icons/lib/md/close"
 import MdQuestionMark from "./question-mark-icon"
 
 const postFeedback = ({ rating, comment }) => {

--- a/src/components/feedback-widget/submit-error.js
+++ b/src/components/feedback-widget/submit-error.js
@@ -3,7 +3,7 @@ import WidgetWrapper from "./widget-wrapper"
 import { CloseButton } from "./buttons"
 import { Actions, ScreenReaderText, Title } from "./styled-elements"
 import { SubmitButton } from "./buttons"
-import { MdArrowForward } from "react-icons/md"
+import MdArrowForward from "react-icons/lib/md/arrow-forward"
 
 const SubmitError = ({ handleClose, handleOpen }) => (
   <WidgetWrapper className="feedback-success" handleClose={handleClose}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8818,10 +8818,17 @@ react-hot-loader@^4.6.2:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-icons@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.5.0.tgz#a6135480e3bcbc63f5dd045193ef2a814263d8d1"
-  integrity sha512-LuKUcavgPWjPrRkIdNbsGw8LqcnhfNN0AGCtU4Td1UkOenJSIWbYppSJrD6zi/TDZOHtTs9opu6ZKB/NFWk21g==
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
+
+react-icons@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
+  integrity sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==
+  dependencies:
+    react-icon-base "2.1.0"
 
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.5"


### PR DESCRIPTION
Verified that this only builds ~5KB of icons — probably worth the full `www` refactor soon (maybe an issue for a community member?), but this'll get us launched in the meantime.